### PR TITLE
Develop/refactoring/self-PR

### DIFF
--- a/frontend/.vscode/settings.json
+++ b/frontend/.vscode/settings.json
@@ -4,5 +4,6 @@
   ],
   "editor.formatOnSave": true,
   "editor.rename.enablePreview": true,
-  "workbench.editor.enablePreview": false
+  "workbench.editor.enablePreview": false,
+  "prettier.jsxSingleQuote": true
 }

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -29,8 +29,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
   `기본, 초성 검색이 가능합니다🧐<br>
   띄어쓰기도 걱정하지 마세요! ex)리 신, 탐 켄치 
   `
-
-
+  
   const teamArr = ['KDF', 'T1', 'DK' ,'BRO' , 'DRX', 'GEN', 'HLE', 'KT', 'LSB', 'NS']
   
   const isMountedRef = useRef(false);
@@ -179,7 +178,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
     updatedArr[currentSelectingIndex] = team[currentSelectingIndex].updateSummoner({type : type, data : data , isConfirmed : isConfirmed})
     
     setTeam(updatedArr)
-  }  
+  }
   
   const updateSpell = (spellName) => {
     let [team, setTeam] = currentSelectingTeam === 'blue' ? [blueTeamSummoner, setBlueTeamSummoner] : [redTeamSummoner, setRedTeamSummoner]
@@ -325,8 +324,39 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
     }
 
     return type
-  }  
+  }
 
+
+  const isPickPhaseEnd = () => {
+    let blueTeamPickPhaseEnd =  !blueTeamSummoner.map(summoner=>summoner.pickedChampion.isConfirmed).includes(false)
+    let redTeamPickPhaseEnd =  !redTeamSummoner.map(summoner=>summoner.pickedChampion.isConfirmed).includes(false)
+
+    return blueTeamPickPhaseEnd && redTeamPickPhaseEnd
+  }
+
+  const isBanPhaseEnd = () => {
+    let blueTeamPickPhaseEnd =  !blueTeamSummoner.map(summoner=>summoner.bannedChampion.isConfirmed).includes(false)
+    let redTeamPickPhaseEnd =  !redTeamSummoner.map(summoner=>summoner.bannedChampion.isConfirmed).includes(false)
+
+    return blueTeamPickPhaseEnd && redTeamPickPhaseEnd
+  }
+  
+  const isSpellPhaseEnd = () => {
+    let blueTeamSpell1Confirmed =  !blueTeamSummoner.map(summoner=>summoner.spell1.isConfirmed).includes(false)
+    let blueTeamSpell2Confirmed =  !blueTeamSummoner.map(summoner=>summoner.spell2.isConfirmed).includes(false)
+    let redTeamSpell1Confirmed =  !redTeamSummoner.map(summoner=>summoner.spell1.isConfirmed).includes(false)
+    let redTeamSpell2Confirmed =  !redTeamSummoner.map(summoner=>summoner.spell2.isConfirmed).includes(false)
+
+    let blueTeamSpellPhaseEnd = blueTeamSpell1Confirmed && blueTeamSpell2Confirmed
+    let redTeamSpellPhaseEnd = redTeamSpell1Confirmed && redTeamSpell2Confirmed
+    
+    return blueTeamSpellPhaseEnd && redTeamSpellPhaseEnd
+  }
+
+  const isAllPickBanPhaseEnd = () => {
+    return isPickPhaseEnd() && isBanPhaseEnd() && isSpellPhaseEnd()
+  }
+  
   const currentSelectingIndexController = () =>{
     const notConfirmedIndexChecker = () =>{        
       let notConfirmedIndex
@@ -341,11 +371,12 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
     }
 
     if(currentSelectingIndex < 4){
-      setCurrentSelectingIndex(currentSelectingIndex + 1)
+      setCurrentSelectingIndex(before => before + 1)
       return
     }    
     notConfirmedIndexChecker()         
-  } 
+  }
+
   const currentSelectingTeamController = () => {
     setCurrentSelectingIndex(0)
 
@@ -410,36 +441,6 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
     setCurrentSelectingSpellNumber(1)
   } 
 
-  const isPickPhaseEnd = () => {
-    let blueTeamPickPhaseEnd =  !blueTeamSummoner.map(summoner=>summoner.pickedChampion.isConfirmed).includes(false)
-    let redTeamPickPhaseEnd =  !redTeamSummoner.map(summoner=>summoner.pickedChampion.isConfirmed).includes(false)
-
-    return blueTeamPickPhaseEnd && redTeamPickPhaseEnd
-  }
-
-  const isBanPhaseEnd = () => {
-    let blueTeamPickPhaseEnd =  !blueTeamSummoner.map(summoner=>summoner.bannedChampion.isConfirmed).includes(false)
-    let redTeamPickPhaseEnd =  !redTeamSummoner.map(summoner=>summoner.bannedChampion.isConfirmed).includes(false)
-
-    return blueTeamPickPhaseEnd && redTeamPickPhaseEnd
-  }
-  
-  const isSpellPhaseEnd = () => {
-    let blueTeamSpell1Confirmed =  !blueTeamSummoner.map(summoner=>summoner.spell1.isConfirmed).includes(false)
-    let blueTeamSpell2Confirmed =  !blueTeamSummoner.map(summoner=>summoner.spell2.isConfirmed).includes(false)
-    let redTeamSpell1Confirmed =  !redTeamSummoner.map(summoner=>summoner.spell1.isConfirmed).includes(false)
-    let redTeamSpell2Confirmed =  !redTeamSummoner.map(summoner=>summoner.spell2.isConfirmed).includes(false)
-
-    let blueTeamSpellPhaseEnd = blueTeamSpell1Confirmed && blueTeamSpell2Confirmed
-    let redTeamSpellPhaseEnd = redTeamSpell1Confirmed && redTeamSpell2Confirmed
-    
-    return blueTeamSpellPhaseEnd && redTeamSpellPhaseEnd
-  }
-
-  const isAllPickBanPhaseEnd = () => {
-    return isPickPhaseEnd() && isBanPhaseEnd() && isSpellPhaseEnd()
-  }
-
   const isCurrentSelectingIndexDataConfirmed = () => {
     let team = currentSelectingTeam === 'blue' ? blueTeamSummoner : redTeamSummoner
     return team[currentSelectingIndex][currentSelectingType()].isConfirmed
@@ -457,11 +458,12 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
     return blueTeamDataConfirmed && redTeamDataConfirmed
   }
 
-  useEffect(()=>{   
+  useEffect(()=>{      
     if(isCurrentSelectingIndexDataConfirmed()){
       currentSelectingIndexController()
       console.log('index 0 ~ 4 순서 이펙트')
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   },[blueTeamSummoner,redTeamSummoner])
 
   useEffect(()=>{
@@ -469,6 +471,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
       currentSelectingTeamController()      
       console.log('team ~ team 순서 이펙트')  
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   },[blueTeamSummoner,redTeamSummoner])
 
   useEffect(()=>{
@@ -476,6 +479,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
       currentPhaseController()
       console.log('phase ~ phase 순서 이펙트')
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   },[blueTeamSummoner,redTeamSummoner])
 
   useEffect(()=>{
@@ -487,6 +491,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
       currentSelectingSpellNumberController()    
       console.log('spellNumber 변경 이펙트')  
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   },[blueTeamSummoner,redTeamSummoner])
 
 

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -68,45 +68,47 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
   })  
 
   class Summoner{
-    constructor(pickedChampion , spell1, spell2, bannedChampion){
+    constructor({
+      pickedChampion = {data : '', isConfirmed : false},
+      bannedChampion = {data : '', isConfirmed : false},
+      spell1 = {data : '', isConfirmed : false},
+      spell2 = {data : '', isConfirmed : false}
+    })
+    {
       this.pickedChampion = pickedChampion
+      this.bannedChampion = bannedChampion
       this.spell1 = spell1
       this.spell2 = spell2
-      this.bannedChampion = bannedChampion
     }
-    setPickedChampion(pickedChampion){
-      return new Summoner(pickedChampion, this.spell1, this.spell2, this.bannedChampion)
-    }
-    setSpell1(spell1){
-      return new Summoner(this.pickedChampion, spell1, this.spell2, this.bannedChampion)
-    }
-    setSpell2(spell2){
-      return new Summoner(this.pickedChampion, this.spell1, spell2, this.bannedChampion)
+
+    updateSummoner({type, data = this[type].data, isConfirmed = this[type].isConfirmed}){
+      return new Summoner({
+        pickedChampion : this.pickedChampion,
+        bannedChampion : this.bannedChampion ,
+        spell1 : this.spell1,
+        spell2 : this.spell2,
+        [type] : {
+          data : data,
+          isConfirmed : isConfirmed
+        }
+      })      
     }    
-    setBannedChampion(bannedChampion){
-      return new Summoner(this.pickedChampion, this.spell1, this.spell2, bannedChampion)
-    }
-    switchingSpell(){
-      return new Summoner(this.pickedChampion, this.spell2, this.spell1 , this.bannedChampion)
-    }
-    isEmpty(data){
-      return this[data] === ''
-    }
   }
 
+
   const [blueTeamSummoner, setBlueTeamSummoner] = useState([
-    new Summoner('','','',''),
-    new Summoner('','','',''),
-    new Summoner('','','',''),
-    new Summoner('','','',''),
-    new Summoner('','','','')
+    new Summoner({}),
+    new Summoner({}),
+    new Summoner({}),
+    new Summoner({}),
+    new Summoner({})
   ])
   const [redTeamSummoner, setRedTeamSummoner] = useState([
-    new Summoner('','','',''),
-    new Summoner('','','',''),
-    new Summoner('','','',''),
-    new Summoner('','','',''),
-    new Summoner('','','','')
+    new Summoner({}),
+    new Summoner({}),
+    new Summoner({}),
+    new Summoner({}),
+    new Summoner({})
   ]) 
 
   const onChangeSearchInput = e => setSearchInput(e.target.value)
@@ -149,104 +151,78 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
   const closeTeamSelectMenu = teamColor => {
     setIsTeamSelectMenuOpen(prevState => ({...prevState , [teamColor] : false}))
   }
-
-  const setPickedChampion = (championName) => {
-    if(currentSelectingTeam === 'blue'){
-      const updatedArr = [...blueTeamSummoner]
-      updatedArr[currentSelectingIndex] = blueTeamSummoner[currentSelectingIndex].setPickedChampion(championName)  
-
-      setBlueTeamSummoner(updatedArr)
-    }
-    else{
-      const updatedArr = [...redTeamSummoner]
-      updatedArr[currentSelectingIndex] = redTeamSummoner[currentSelectingIndex].setPickedChampion(championName)
-
-      setRedTeamSummoner(updatedArr)
-    }
-  }
-
-  const setBannedChampion = (championName) => {
-    if(currentSelectingTeam === 'blue'){
-      const updatedArr = [...blueTeamSummoner]
-      updatedArr[currentSelectingIndex] = blueTeamSummoner[currentSelectingIndex].setBannedChampion(championName)  
-
-      setBlueTeamSummoner(updatedArr)
-    }
-    else{
-      const updatedArr = [...redTeamSummoner]
-      updatedArr[currentSelectingIndex] = redTeamSummoner[currentSelectingIndex].setBannedChampion(championName)
-
-      setRedTeamSummoner(updatedArr)
-    }
-  }
-
-  const setSpell = (spellName) => {
-    let currentSpell1 
-    let currentSpell2
+  
+  const setSummonerData = (type, data) => {
     let updatedArr
-    
-    if(currentSelectingTeam === 'blue'){      
-      currentSpell1 = blueTeamSummoner[currentSelectingIndex].spell1
-      currentSpell2 = blueTeamSummoner[currentSelectingIndex].spell2      
+
+    if(currentSelectingTeam === 'blue'){
       updatedArr = [...blueTeamSummoner]
+      updatedArr[currentSelectingIndex] = blueTeamSummoner[currentSelectingIndex].updateSummoner({type : type, data : data})
 
-      if((currentSelectingSpellNumber === 1 && spellName === currentSpell2) ||
-        (currentSelectingSpellNumber === 2 && spellName === currentSpell1)){
-        updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex].switchingSpell()
-        setBlueTeamSummoner(updatedArr)
-        return
-      }      
-
-      updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex][`setSpell${currentSelectingSpellNumber}`](spellName)  
       setBlueTeamSummoner(updatedArr)
-    }    
-    else{
-      currentSpell1 = redTeamSummoner[currentSelectingIndex].spell1
-      currentSpell2 = redTeamSummoner[currentSelectingIndex].spell2      
+    } else{
       updatedArr = [...redTeamSummoner]
+      updatedArr[currentSelectingIndex] = redTeamSummoner[currentSelectingIndex].updateSummoner({type : type, data : data})
 
-      if((currentSelectingSpellNumber === 1 && spellName === currentSpell2) ||
-      (currentSelectingSpellNumber === 2 && spellName === currentSpell1)){
-        updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex].switchingSpell()
-        setRedTeamSummoner(updatedArr)
-        return
-      }      
+      setRedTeamSummoner(updatedArr)
+    }
+  }  
 
-      updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex][`setSpell${currentSelectingSpellNumber}`](spellName)  
+  const setConfirmData = (type) => {
+    let updatedArr
+
+    if(currentSelectingTeam === 'blue'){
+      updatedArr = [...blueTeamSummoner]
+      updatedArr[currentSelectingIndex] = blueTeamSummoner[currentSelectingIndex].updateSummoner({type : type, isConfirmed: true})
+
+      setBlueTeamSummoner(updatedArr)
+    } else{
+      updatedArr = [...redTeamSummoner]
+      updatedArr[currentSelectingIndex] = redTeamSummoner[currentSelectingIndex].updateSummoner({type : type, isConfirmed: true})
+
       setRedTeamSummoner(updatedArr)
     }
   }
+
+  // const setSpell = (spellName) => {
+  //   let currentSpell1 
+  //   let currentSpell2
+  //   let updatedArr
+    
+  //   if(currentSelectingTeam === 'blue'){      
+  //     currentSpell1 = blueTeamSummoner[currentSelectingIndex].spell1
+  //     currentSpell2 = blueTeamSummoner[currentSelectingIndex].spell2      
+  //     updatedArr = [...blueTeamSummoner]
+
+  //     if((currentSelectingSpellNumber === 1 && spellName === currentSpell2) ||
+  //       (currentSelectingSpellNumber === 2 && spellName === currentSpell1)){
+  //       updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex].switchingSpell()
+  //       setBlueTeamSummoner(updatedArr)
+  //       return
+  //     }      
+
+  //     updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex][`setSpell${currentSelectingSpellNumber}`](spellName)  
+  //     setBlueTeamSummoner(updatedArr)
+  //   }    
+  //   else{
+  //     currentSpell1 = redTeamSummoner[currentSelectingIndex].spell1
+  //     currentSpell2 = redTeamSummoner[currentSelectingIndex].spell2      
+  //     updatedArr = [...redTeamSummoner]
+
+  //     if((currentSelectingSpellNumber === 1 && spellName === currentSpell2) ||
+  //     (currentSelectingSpellNumber === 2 && spellName === currentSpell1)){
+  //       updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex].switchingSpell()
+  //       setRedTeamSummoner(updatedArr)
+  //       return
+  //     }      
+
+  //     updatedArr[currentSelectingIndex] = updatedArr[currentSelectingIndex][`setSpell${currentSelectingSpellNumber}`](spellName)  
+  //     setRedTeamSummoner(updatedArr)
+  //   }
+  // }
 
   const onClickChampionPickButton = () => {
-    if(isGlobalPickBanPhaseEnd()){      
-      setGlobalPhase('GoalEdit')
-      setPickBanPhase('End')
-      return
-    }
-
-    if(isPickPhaseEnd()){
-      setPickBanPhase('Ban')
-      setCurrentSelectingIndex(0)
-      setCurrentSelectingTeam('blue')
-      return
-    }   
-
-    if(isCurrentSelectingDataEmpty('pickedChampion')){
-      return
-    }
-
-    if(currentSelectingIndex < 4){
-      setCurrentSelectingIndex(currentSelectingIndex + 1)
-      return
-    }    
-    
-    if(currentSelectingTeam === 'blue'){
-      setCurrentSelectingTeam('red')
-    } else{
-      setCurrentSelectingTeam('blue')
-    }
-    
-    setCurrentSelectingIndex(0)
+    setConfirmData('pickedChampion')
   }
   
   const onClickChampionBanButton = () => {
@@ -420,10 +396,10 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
   }
   
   const bannedChampionImgSrc = (summoner) => {   
-    switch (summoner.bannedChampion){
+    switch (summoner.bannedChampion.data){
       case '' : return transparencyImg
       case 'noBan' : return noBanIcon
-      default : return `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/champion/${summoner.bannedChampion}.png` 
+      default : return `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/champion/${summoner.bannedChampion.data}.png` 
     }      
   }
   const zoomViewImgSrc = (spellNumber) => {
@@ -440,16 +416,34 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
     activatePlayerPrefix()       
     console.log('activate PlayerPrefix')
   },[activatePlayerPrefix])
-  
-  useEffect(()=>{ //activateSpellPlaceholder
-    if(mode === 'rapid' && isMountedRef.current === true){
-      activateSpellPlaceholder()
-      console.log('activate Spell Placeholder')
-      return
-    }
-    isMountedRef.current = true;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  },[board])   
+
+  const currentSelectingIndexController = () => {
+    if(currentSelectingTeam === 'blue'){
+      if(blueTeamSummoner[currentSelectingIndex].pickedChampion.isConfirmed === true){
+        setCurrentSelectingIndex(currentSelectingIndex + 1)
+        return
+      }      
+    } 
+
+    if(redTeamSummoner[currentSelectingIndex].pickedChampion.isConfirmed === true){
+      setCurrentSelectingIndex(currentSelectingIndex + 1)
+    }    
+  }
+  useEffect(()=>{
+    currentSelectingIndexController()
+  },[blueTeamSummoner[currentSelectingIndex].pickedChampion.isConfirmed,
+    redTeamSummoner[currentSelectingIndex].pickedChampion.isConfirmed])
+
+ 
+  // useEffect(()=>{ //activateSpellPlaceholder
+  //   if(mode === 'rapid' && isMountedRef.current === true){
+  //     activateSpellPlaceholder()
+  //     console.log('activate Spell Placeholder')
+  //     return
+  //   }
+  //   isMountedRef.current = true;
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // },[board])   
 
   useEffect(()=>{ // updateMatchChampDataList
     updateMatchChampDataList()
@@ -589,7 +583,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
         {
           blueTeamSummoner.map((summoner, index)=>(
             <div className="summoner" key={index} data-current-target={currentSelectingTeam === 'blue' && currentSelectingIndex === index && pickBanPhase === 'Pick'}>
-              <img className="champion" id={`${summoner.pickedChampion}`} alt={`blueTeam-${index}-${summoner.pickedChampion}`}  
+              <img className="champion" id={`${summoner.pickedChampion.data}`} alt={`blueTeam-${index}-${summoner.pickedChampion.data}`}  
               data-current-target={currentSelectingTeam === 'blue'  && currentSelectingIndex === index && pickBanPhase === 'Pick'}
               onClick={() =>{
                 setCurrentSelectingIndex(index)
@@ -598,12 +592,12 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
                 setGlobalPhase('PickBan')
               }}
               src={                  
-                summoner.pickedChampion === ''
+                summoner.pickedChampion.data === ''
                 ? transparencyImg
-                : `${process.env.REACT_APP_API_BASE_URL}/cdn/img/champion/splash/${summoner.pickedChampion}_0.jpg`
+                : `${process.env.REACT_APP_API_BASE_URL}/cdn/img/champion/splash/${summoner.pickedChampion.data}_0.jpg`
               }/>
               <div className="spell">
-                <img alt={`spell1-${summoner.spell1}`} 
+                <img alt={`spell1-${summoner.spell1.data}`} 
                 onClick={() => {
                   setCurrentSelectingSpellNumber(1)
                   setCurrentSelectingIndex(index)
@@ -613,11 +607,11 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
                 }}
                 data-current-target={currentSelectingTeam === 'blue' && currentSelectingIndex === index && pickBanPhase === 'Spell' && currentSelectingSpellNumber === 1}
                 src={
-                  summoner.spell1 === ''
+                  summoner.spell1.data === ''
                   ? transparencyImg
-                  : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell1}.png`
+                  : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell1.data}.png`
                 }/>
-                <img alt={`spell2-${summoner.spell2}`} 
+                <img alt={`spell2-${summoner.spell2.data}`} 
                 onClick={() => {
                   setCurrentSelectingSpellNumber(2)
                   setCurrentSelectingIndex(index)
@@ -627,9 +621,9 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
                 }}
                 data-current-target={currentSelectingTeam === 'blue' && currentSelectingIndex === index && pickBanPhase === 'Spell' && currentSelectingSpellNumber === 2}
                 src={ 
-                  summoner.spell2 === ''
+                  summoner.spell2.data === '' 
                   ? transparencyImg
-                  : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell2}.png`
+                  : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell2.data}.png`
                 }/>
               </div>
               <input className="player" type='text' value={player[`blue${index + 1}`]} spellCheck='false'
@@ -665,12 +659,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
                 data-picked={isPickedChampion(championData.id)} 
                 data-banned={isBannedChampion(championData.id)}
                 onClick={()=>{
-                  if(pickBanPhase === 'Pick'){
-                    setPickedChampion(championData.id)                 
-                  }
-                  else{
-                    setBannedChampion(championData.id)
-                  };            
+                  setSummonerData('pickedChampion', championData.id)     
                 }}
                 >
                   <img className="champion__img" alt={championData.id} src={`${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/champion/${championData.id}.png`}/>
@@ -703,7 +692,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
           <div className="champions">
             <div className="champion__card"
               onClick={()=>{    
-                setBannedChampion('noBan')
+                setSummonerData('bannedChampion', 'noBan')    
               }}
               >
               <img className="champion__img" alt="no-ban-icon" src={noBanIcon} />
@@ -715,12 +704,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
                 data-picked={isPickedChampion(championData.id)} 
                 data-banned={isBannedChampion(championData.id)}
                 onClick={()=>{
-                  if(pickBanPhase === 'Pick'){
-                    setPickedChampion(championData.id)                 
-                  }
-                  else{
-                    setBannedChampion(championData.id)
-                  };            
+                  setSummonerData('bannedChampion', championData.id)    
                 }}
                 >
                   <img className="champion__img" alt={championData.id} src={`${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/champion/${championData.id}.png`}/>
@@ -767,7 +751,6 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
               <div className="spell__card" key={index}
               data-picked-spell={isPickedSpell(spell.id)}
               onClick={()=>{
-                setSpell(spell.id)
                 onClickCurrentSelectingSpellNumberHandler()
               }}>                  
                 <img className="spell__img" alt={`spell-img-${spell.id}`} src={`${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${spell.id}.png`}/>
@@ -863,7 +846,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
       {
         redTeamSummoner.map((summoner, index)=>(
           <div className="summoner" key={index} data-current-target={currentSelectingTeam === 'red' && currentSelectingIndex === index && pickBanPhase === 'Pick'}>
-            <img className="champion" id={`${summoner.pickedChampion}`} alt={`${summoner.pickedChampion}`}
+            <img className="champion" id={`${summoner.pickedChampion.data}`} alt={`${summoner.pickedChampion.data}`}
             data-current-target={currentSelectingTeam === 'red' && currentSelectingIndex === index && pickBanPhase === 'Pick'}
             onClick={() =>{
               setCurrentSelectingIndex(index)
@@ -872,9 +855,9 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
               setGlobalPhase('PickBan')
             }}  
             src={                  
-              summoner.pickedChampion === ''
+              summoner.pickedChampion.data === ''
               ? transparencyImg
-              : `${process.env.REACT_APP_API_BASE_URL}/cdn/img/champion/splash/${summoner.pickedChampion}_0.jpg`
+              : `${process.env.REACT_APP_API_BASE_URL}/cdn/img/champion/splash/${summoner.pickedChampion.data}_0.jpg`
             }/>
             <div className="spell">
               <img alt="spell1"
@@ -886,9 +869,9 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
               }}
               data-current-target={currentSelectingTeam === 'red' && currentSelectingIndex === index && pickBanPhase === 'Spell' && currentSelectingSpellNumber === 1}
               src={
-                summoner.spell1 === ''
+                summoner.spell1.data === ''
                 ? transparencyImg
-                : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell1}.png`
+                : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell1.data}.png`
               }/>
               <img alt="spell2" 
               onClick={() => {
@@ -899,9 +882,9 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
               }}
               data-current-target={currentSelectingTeam === 'red' && currentSelectingIndex === index && pickBanPhase === 'Spell' && currentSelectingSpellNumber === 2}
               src={                  
-                summoner.spell2 === ''
+                summoner.spell2.data === ''
                 ? transparencyImg
-                : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell2}.png`
+                : `${process.env.REACT_APP_API_BASE_URL}/cdn/${recentVersion}/img/spell/${summoner.spell2.data}.png`
               }/>
             </div>
             <input className="player" type='text' value={player[`red${index + 1}`]} spellCheck='false'
@@ -919,7 +902,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
         blueTeamSummoner.map((summoner, index) => (
           <div className='banned-champion-wrap' key={index} 
           data-current-target={currentSelectingTeam === 'blue' && currentSelectingIndex === index && pickBanPhase === 'Ban'}>
-            <img className='banned-champion' alt={`blueTeam-banned-${index}-${summoner.bannedChampion}`}
+            <img className='banned-champion' alt={`blueTeam-banned-${index}-${summoner.bannedChampion.data}`}
             data-current-target={currentSelectingTeam === 'blue' && currentSelectingIndex === index && pickBanPhase === 'Ban'}
             onClick={()=>{
               setCurrentSelectingTeam('blue')
@@ -944,7 +927,7 @@ export default function Board({recentVersion, ascendingChampionDataList , classi
         redTeamSummoner.map((summoner, index) => (
           <div className='banned-champion-wrap' key={index}
           data-current-target={currentSelectingTeam === 'red' && currentSelectingIndex === index && pickBanPhase === 'Ban'}>
-            <img className='banned-champion' alt={`redTeam-banned-${index}-${summoner.bannedChampion}`}
+            <img className='banned-champion' alt={`redTeam-banned-${index}-${summoner.bannedChampion.data}`}
             data-current-target={currentSelectingTeam === 'red' && currentSelectingIndex === index && pickBanPhase === 'Ban'}
             onClick={()=>{
               setCurrentSelectingTeam('red')

--- a/frontend/src/scss/_Board.scss
+++ b/frontend/src/scss/_Board.scss
@@ -1108,6 +1108,9 @@
       &[id="Volibear"] {
         transform: scaleX(-1);
       }
+      &[id='Belveth']{
+        transform: scaleX(-1);
+      }
       &[id="Braum"] {
         transform: scaleX(-1);
       }


### PR DESCRIPTION
1차 배포 이후 코드의 정돈과 수정이 필요하다고 느꼈고, 코드를 바꿔가면서 계속해서 새로운 문제점을 발견했다.
하나의 수정은 또 다른 수정을 만들고, 계속 수정을 이어가다 보니 전체적인 구조의 문제점까지 드러났다.

코드 작성 중 어떤 부분에 제약을 받았으면 어딘가 문제가 있다고 생각했어야 하는데,
구현과 정상적인 동작만을 목표로 하며 스스로 계속 제약을 추가해 나간 것 같다.
그 과정에서 코드끼리의 결합도가 너무 높아진 것 같다.

코드를 최대한 수정을 해보았고, 
앞으로 만들 수많은 프로젝트에서, 더 생각하며 코드를 작성하기 위해 정리를 해보려고 한다.

### 수정한 코드와 이유, 개선한 방향, 이로 인한 이점
---

1. **수정한 코드** : 선택을 확정한다는 의미의 버튼에 달아 놓은 onCilck 함수

    **수정한 이유** :  
    함수에서 확정과 상관없는 여러 가지의 동작을 담당하고 있었다.   
    이 함수는 사용자로 하여금 자신의 선택이 확정됐다는 느낌을 주기 위해 구현했었다.
    현재 선택 중인 summoner, team, phase 와 같은 상태들을 변경하는 로직이었고 
    이는 겉으로는 그럴듯하게 동작했지만, 
    내부적으로는 하나의 함수에 너무 많은 동작과 이에 대한 조건들로 구성되어 있어 좋지 않았다.

   **개선한 방향** : 
Summoner class에 각 데이터마다 확정 상태를 나타내는 'isConfirmed' 프로퍼티 추가
기존 버튼 onClick 함수는 현재 선택 중인 데이터의 확정 상태만 조작
데이터의 확정 상태에 따라 summoner, team, phase 상태를 변경하는 개별 useEffect 추가 

   **개선 후 이점** :  코드의 흐름이 조금 더 자연스러워졌고, 함수의 동작이 분리되어, 각 로직의 의미 파악이 비교적 쉬워졌다.

---
                          
2. **수정한 코드** :  Summoner class의 constructor 구조

    **수정한 이유** :  1번을 수정하면서 Summoner class의 constructor 구조 수정이 불가피했다.
   
    **개선한 방향** :  
   constructor의 각 파라미터가 객체를 받아오게 하였고,
   default parameter를 사용해서 빈 객체를 전달하여도 인스턴스 생성이 가능하게 수정하였다.
 
    **개선 후 이점** : 
    위 1번의 개선이 가능한 구조가 되었고, 
    팀 별 인스턴스 생성 시, 인자로 일일이 빈 문자열 ''을 전달할 필요도 없어졌다.
    
---

3. **수정한 코드** :  Summoner class의 데이터 type별 set메소드

    **수정한 이유** :  
   데이터 type( 4개 ) 만큼 데이터 set메소드가 존재했다. 
   데이터 type 과는 상관없이 '데이터를 수정한다'라는 공통적인 동작을 하고 있었기 때문에, 개별로 존재할 이유가 없었다.

    **개선한 방향** :  
   데이터의 type, data, isConfirmed 가 담긴 객체를 인자로 받고, 받지 못한 인자는 default parameter를 통해 기존 값을 사용하여
   수정된 객체를 리턴하는 updateSummoner() 를 만들었다.
 
    **개선 후 이점** : 
   type만 제공한다면, data 나 isConfirmed를 하나의 메소드로 수정 가능하게 되었다. 
   메소드 실행에 필요한 함수도 1개로 줄었고, class 내의 불필요한 코드가 정리되었다. 

---
### 다음부터 꼭 신경 써야할 것들

1. setState, useEffect, useCallback을 사용할 때 반드시 리랜더링과 시간에 따른 흐름( 동기, 비동기 )을 생각하고 코드를 작성할 것.
   ( eslint-disable-next-line 사용할 일 최대한 만들지 말기)

2. 어쩔 수 없는 선택을 할 때, 정말 모든 경우의 수를 전부 시도해 봤는지 다시 한번 검토할 것.
    ( 나중에 코드를 봤을 때 100에 95는 '이렇게도 해볼 수 있었나 ?' 같은 생각을 함 )

3. es6 class를 배운 뒤 코드에 처음 사용해보았는데, 
  검색 결과 state에 class 인스턴스를 넣는 것은 그닥 좋지 않은 방식같다.

    -> 괜찮다!  https://stackoverflow.com/questions/68035988/react-usestate-with-es6-classes
    -> 좋지 않다! custom hook을 사용해라!  
      https://stackoverflow.com/questions/66062826/is-there-a-react-way-to-store-a-mutable-class-instance-objects-in-state

    요약하면 '어찌됐든 컴포넌트의 리렌더를 최대한 줄일 수 있는 방법을 고려하고 사용해라~' 라는 말이었다.
    나는 후자의 방식이 좋은 방향이라고 생각했고 다음 코드부터는 custom hook을 사용해볼 생각이다.
